### PR TITLE
Drop Upbound context check in entrypoint

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -32,8 +32,6 @@ import (
 	"github.com/upbound/official-provider-template/internal/features"
 )
 
-const upboundCTXEnv = "UPBOUND_CONTEXT"
-
 func main() {
 	var (
 		app              = kingpin.New(filepath.Base(os.Args[0]), "Terraform based Crossplane provider for Template").DefaultEnvars()
@@ -48,11 +46,6 @@ func main() {
 		namespace                  = app.Flag("namespace", "Namespace used to set as default scope in default secret store config.").Default("crossplane-system").Envar("POD_NAMESPACE").String()
 		enableExternalSecretStores = app.Flag("enable-external-secret-stores", "Enable support for ExternalSecretStores.").Default("false").Envar("ENABLE_EXTERNAL_SECRET_STORES").Bool()
 	)
-
-	// If UPBOUND_CONTEXT is not set, we refuse to run.
-	if _, set := os.LookupEnv(upboundCTXEnv); !set {
-		kingpin.Fatalf("Running this provider outside of an Upbound distribution is prohibited by license. Please contact support@upbound.io for more information.")
-	}
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->

Drops the Upbound context check as it is not required for upjet-based providers.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

Ran locally without Upbound context set.

[contribution process]: https://git.io/fj2m9
