### PR TITLE
Instantiate Features object in xpcontrollers

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -12,6 +12,7 @@ import (
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	xpcontroller "github.com/crossplane/crossplane-runtime/pkg/controller"
+	"github.com/crossplane/crossplane-runtime/pkg/feature"
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -80,6 +81,7 @@ func main() {
 			GlobalRateLimiter:       ratelimiter.NewGlobal(*maxReconcileRate),
 			PollInterval:            1 * time.Minute,
 			MaxConcurrentReconciles: 1,
+			Features:                &feature.Flags{},
 		},
 		Provider: config.GetProvider(),
 		// use the following WorkspaceStoreOption to enable the shared gRPC mode


### PR DESCRIPTION
### Description of your changes

We get a NullPointer reference when enabling the management policies feature, as the features struct hasn't been initialized. I thus initialized the struct. This works now for me locally, but appreciate this may not be the best way to fix this issue - so feel free to scrap this PR / solve in another way if preferred.

Issue: #44

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Tested with my own provider and I no longer received the above segfault, the management policies (namely observe only) also work as intended.

[contribution process]: https://git.io/fj2m9

### Example of the current broken state state:
```
12:59:11 [ .. ] Running Crossplane locally out-of-cluster . . .
UPBOUND_CONTEXT="local" provider-vsphere/_output/bin/linux_amd64/provider --debug --enable-management-policies
2023-06-29T12:59:11-04:00       DEBUG   provider-vsphere        Starting        {"sync-period": "1h0m0s"}
I0629 12:59:13.198152 1427100 request.go:690] Waited for 1.045899544s due to client-side throttling, not priority and fairness, request: GET:k8s.api.com/apis/windows.k8s.io/v1alpha1?timeout=32s
2023-06-29T12:59:13-04:00       INFO    controller-runtime.metrics      Metrics server is starting to listen    {"addr": ":8080"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x13e0e67]

goroutine 1 [running]:
github.com/crossplane/crossplane-runtime/pkg/feature.(*Flags).Enable(0x0, {0x1d5e810, 0x1d})
        github.com/crossplane/crossplane-runtime@v0.20.0-rc.0.0.20230406155702-4e1673b7141f/pkg/feature/feature.go:35 +0x27
main.main()
        provider-vsphere/cmd/provider/main.go:111 +0x1d98
make: *** [Makefile:161: run] Error 2
```