### PR TITLE
fix(ci): set default workflow permissions to read-only

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -10,6 +10,12 @@ on:
     types: [closed]
   # See also commands.yml for the /backport triggered variant of this workflow.
 
+permissions:
+  contents: read
+
 jobs:
   backport:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: upbound/official-providers-ci/.github/workflows/provider-backport.yml@standard-runners

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request: {}
   workflow_dispatch: {}
 
+permissions:
+  contents: read
+
 env:
   # Common versions
   GO_VERSION: '1.21'

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -2,6 +2,12 @@ name: Comment Commands
 
 on: issue_comment
 
+permissions:
+  contents: read
+
 jobs:
   comment-commands:
+    permissions:
+      contents: write
+      pull-requests: write
     uses: upbound/official-providers-ci/.github/workflows/provider-commands.yml@standard-runners

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -4,8 +4,15 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   e2e:
+    permissions:
+      contents: read
+      statuses: write
+      pull-requests: read
     uses: upbound/official-providers-ci/.github/workflows/pr-comment-trigger.yml@standard-runners
     secrets:
       UPTEST_CLOUD_CREDENTIALS: ${{ secrets.UPTEST_CLOUD_CREDENTIALS }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -10,8 +10,13 @@ on:
         description: 'Tag message'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   tag:
+    permissions:
+      contents: write
     uses: upbound/official-providers-ci/.github/workflows/provider-tag.yml@standard-runners
     with:
       version: ${{ github.event.inputs.version }}


### PR DESCRIPTION
- Follow the least-privilege pattern adopted across the Crossplane ecosystem (see crossplane/crossplane#7131) to improve the OpenSSF Scorecard Token Permissions score