### PR TITLE
Add agentic skills for provider review and development

### DIFF
--- a/.agent/skills/add-upjet-resource/SKILL.md
+++ b/.agent/skills/add-upjet-resource/SKILL.md
@@ -24,7 +24,7 @@ Upjet providers wrap a Terraform provider: adding a resource is config-only — 
 
 The repo's `CLAUDE.md` (if present) has the full map. Common files you touch:
 
-- `config/external_name.go` — `ExternalNameConfigs` map. **Also gates generation**: a resource absent here is never generated (it feeds `WithIncludeList` / `WithTerraformPluginFrameworkIncludeList`).
+- `config/external_name.go` — `ExternalNameConfigs` map. **Also gates generation**: a resource absent here is never generated (it feeds `WithIncludeList` / `WithTerraformPluginSDKIncludeList` / `WithTerraformPluginFrameworkIncludeList`, depending on which SDK the resource uses).
 - `config/provider.go` — top-level provider wiring; registers group `Configure` functions and sets `WithRootGroup`.
 - `config/{cluster,namespaced}/<group>/config.go` — per-group `AddResourceConfigurator`; cross-resource references live here. **Keep the two copies identical.**
 - `config/{cluster,namespaced}/provider.go` — registers each group's `Configure` (if the provider uses this pattern — some providers consolidate in a single `config/provider.go`).
@@ -50,7 +50,7 @@ PY
 grep -n "<TF_NAME>:" -A40 config/provider-metadata.yaml
 ```
 
-**2. `config/external_name.go`** — add the resource with the right external-name strategy. Choose based on how the provider assigns resource IDs:
+**2. `config/external_name.go`** — add the resource with the right external-name strategy. Choose based on how the provider assigns resource IDs. Official guides: [adding-new-resource.md](https://github.com/crossplane/upjet/blob/main/docs/adding-new-resource.md) and [configuring-a-resource.md](https://github.com/crossplane/upjet/blob/main/docs/configuring-a-resource.md).
 
 ```go
 // Provider assigns a computed ID (import by id) — most common
@@ -69,7 +69,8 @@ grep -n "<TF_NAME>:" -A40 config/provider-metadata.yaml
 **How to determine the right strategy:**
 - Check `config/schema.json`: if the resource has `"id"` in its schema block with `"computed": true` and no useful fields form the import path → `IdentifierFromProvider`.
 - Check `provider-metadata.yaml` `importStatements` for the import pattern — it shows whether import uses `id`, `name`, or a composite key.
-- Check `go.mod` for `github.com/hashicorp/terraform-plugin-framework` — if present, the TF provider uses the framework backend and you must use `FrameworkResourceWithComputedIdentifier` (not `IdentifierFromProvider`).
+- **Import path ≠ ID format (rare but critical):** On the Terraform side, the import path and the runtime ID can differ. Upjet routes both observe and import through the same code path, so if the import pattern doesn't match the actual ID format the resource emits, Upjet will use the import path as the source of truth — causing the resource to leak or import to fail. When `importStatements` and the `id` in `schema.json` look different, prefer the **ID format** (what the resource actually returns after create) over the import path.
+- **Per-resource SDK check — do not rely solely on `go.mod`:** A provider can mix SDK v2 and Plugin Framework resources in the same repo (e.g. AWS). Having `github.com/hashicorp/terraform-plugin-framework` in `go.mod` does not mean every resource uses it. Check the **resource's own source file**: if it imports `github.com/hashicorp/terraform-plugin-framework` or carries a `// @FrameworkResource` / `// @SDKv2` annotation, use `FrameworkResourceWithComputedIdentifier`; otherwise use the standard SDK external-name helpers.
 - For the ID placeholder in `FrameworkResourceWithComputedIdentifier`: list a real resource of this type via the provider's cloud CLI and copy the ID format. The placeholder must be a syntactically valid ID of that type — wrong format fails the initial observe before any create.
 
 **3. Group and Kind naming** — determine `<group>` and `<kind>` for the new resource.
@@ -98,14 +99,18 @@ p.AddResourceConfigurator("<TF_NAME>", func(r *config.Resource) {
     }
 })
 ```
-- Reference keys are **dotted snake_case TF attribute paths**. Nested single objects work: `network.subnet_id`, `config.source_id`. **Never use `[*]`** for list elements — Upjet silently drops it.
-- A field is a reference only if its target is a resource THIS provider manages. Fields pointing at types not in the provider → leave as plain fields, no reference.
+- Reference keys are **dotted snake_case TF attribute paths**, written WITHOUT any list index token. Nested single objects work (`network.subnet_id`), and so does **traversing list elements** — Upjet emits a per-element `<field>Ref`/`<field>Selector` inside each slice item. **Never write the literal `[*]`** (that token is silently dropped); just use the plain dotted path even when a segment is a list. Verified: `healthcheck.name` (where `healthcheck` is a `max_items=None` list) and even a deeply nested `origin_servers.k8s_service.site_locator.virtual_site.name` (a list element → singleton objects) both generate working ref fields.
+- **Don't skip a reference just because the path is deep or crosses a list.** If the target is a managed type, wire it. The only hard rule is the `[*]` token. After generating, **verify the `Ref`/`Selector` fields actually appear** at that path in `package/crds/<...>.yaml` (dump the nested properties) — that confirms Upjet didn't drop the path. The same managed field may appear under several sibling blocks (e.g. `virtual_site` under `consul_service`/`k8s_service`/`private_ip`/`private_name`); add the reference for each and a small `for` loop over the block names keeps it DRY.
+- A field is a reference only if its target is a resource THIS provider manages. Fields pointing at types not in the provider → leave as plain fields, no reference. (A type listed in `GroupMap` but absent from `ExternalNameConfigs` is NOT generated → not managed → no reference.)
+- **No comments on `r.References[...]` entries.** The reference itself is self-documenting. Reserve comments for `config.MoveToStatus` calls, where the reader would otherwise not know why the field was removed from spec.
 
 **5. `make generate`** (~2–5 min; downloads terraform, pulls docs, regenerates). It rewrites `apis/`, `internal/controller/`, `package/crds/`, `examples-generated/`, and **`config/generated.lst` automatically — never hand-edit `generated.lst`.** Codegen creates the whole API/controller package for a brand-new group on its own (no manual wiring for the group itself). If it fails with `No rule to make target 'generate'`, the `build/` git submodule is uninitialized (common in fresh worktrees) — run `git submodule update --init --recursive` and retry.
 
 **6. `go build ./...`** to confirm. Expect a wide but benign diff (see Gotchas).
 
 **7. Curate `examples/`** from `examples-generated/` — see Examples below.
+
+**8. Validate** — run `make e2e` to confirm the resource reconciles against the real cloud API. See E2E testing & debugging below.
 
 ## New group vs existing group
 
@@ -142,7 +147,8 @@ For each new resource write `examples/{cluster,namespaced}/<group>/v1beta1/<kind
   - Nested: walk the schema, `r.TerraformResource.Schema["<parent>"].Elem.(*schema.Resource).Schema["<field>"].Sensitive = true` (import `github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema`)
 - **namespaced copy** = same content with `apiVersion: <group>.<namespaced-domain>/v1beta1` and `namespace: upbound-system` on every doc (the raw `v1 Secret` deps are already in `upbound-system`, so they are identical across scopes).
 - **No `examples:` block in provider-metadata.yaml → no generated example.** Hand-build it from the CRD schema in `package/crds/`.
-- Validate field names/enums against the generated CRD before finishing.
+- **`examples-generated/` is structurally naive — the CRD in `package/crds/` is the source of truth.** Generated examples mirror the raw Terraform schema and are **not aware of schema conversions** the provider applies, most commonly `SingletonListEmbedder` (`WithSchemaTraversers`), which collapses a `max_items=1` TF list block into a **single embedded object** in the CRD. So a generated example may show such a block as a YAML **list** (`siteSelector:` / `- expressions:`) while the CRD actually requires a **single object** (`siteSelector:` / `  expressions:` with no `-`). Build the curated `examples/` to match the **CRD** shape, not `examples-generated/`. **Do not "fix" `examples-generated/`** — it is regenerated and intentionally conversion-unaware; only your `examples/` copy must be correct. To see the true shape, read the field's `type` (`object` vs `array`) in `package/crds/<...>.yaml`.
+- Validate field names/enums **and nesting (object vs list)** against the generated CRD in `package/crds/` before finishing.
 
 ## E2E testing & debugging
 
@@ -157,7 +163,7 @@ make e2e
 ```
 `UPTEST_CLOUD_CREDENTIALS` is the **contents** of the credentials file (note the `$(cat ...)`); `UPTEST_DATASOURCE_PATH` is the **path** to a datasource file that resolves injectable values like `${data.<provider>_project_id}` (lines like `<provider>_project_id: <id>`). Confirm both paths with the user before running. `make e2e` builds the provider, (re)creates a KinD cluster, deploys the provider, then uptest (chainsaw) applies the example, waits for `Ready`, then deletes and asserts deletion. **Exit 0 = validated** (look for `Passed tests 1, Failed tests 0`).
 
-**Watch the resource's conditions live — don't wait for `make e2e` to finish.** Once the provider is deployed and the example applied, the managed resource's `status.conditions` carry the verdict minutes before uptest gives up. Run `make e2e` in the background, then run a **second** background poller that exits the instant a resource is decisive (`Ready=True`, or `Synced=False` = error):
+**Watch the resource's conditions proactively — do NOT wait passively for `make e2e` to finish.** Once `make e2e` is running in the background, start polling immediately: check the output file every ~30s and query the resource conditions as soon as the managed resource appears. Act on the first `Synced=False` error — patch the running cluster and force a reconcile rather than waiting for the E2E timeout. The skill's loop below exits as soon as a verdict is reached; run it after launching E2E:
 ```bash
 # Adjust <kind>, <group>.<domain>, and <name> to match the resource under test
 CTX=<kind-cluster-context>   # e.g. kind-local-dev
@@ -211,7 +217,7 @@ Order is non-negotiable. `make e2e` does NOT delete managed resources before its
 |---|---|
 | Resource added to group map but not generated | It must also be in `ExternalNameConfigs` — that map drives the include list. |
 | Wrong external-name strategy | Check `importStatements` in `provider-metadata.yaml` and whether the TF provider uses the plugin-framework (`go.mod`). |
-| Reference on a list field via `key[*].id` | `[*]` is silently dropped by Upjet. Use dotted path; genuine list-element refs need care and testing. |
+| Reference on a list field via `key[*].id` | Only the literal `[*]` token is dropped. The plain dotted path (`key.id`) DOES traverse list elements and emits per-element `Ref`/`Selector` — verify they appear in the CRD. |
 | Editing `config/generated.lst` by hand | It is regenerated by `make generate`; leave it. |
 | Wide diff in already-committed `zz_*_types.go` after generate | Benign: adding resources that also have `metadata`/`status` makes Upjet rename shared types package-wide. Fine as long as `go build ./...` passes. |
 | Edited only `config/cluster/.../config.go` | The namespaced copy must match — references are duplicated in both scopes. |

--- a/.agent/skills/add-upjet-resource/SKILL.md
+++ b/.agent/skills/add-upjet-resource/SKILL.md
@@ -1,0 +1,237 @@
+---
+name: add-upjet-resource
+description: ⚠️ EXPERIMENTAL Use when adding a Terraform resource to an Upjet-based Crossplane provider — wiring it into config so `make generate` emits its cluster + namespaced CRDs/controllers, and preparing examples.
+---
+
+# Add an Upjet Resource
+
+## Overview
+
+Upjet providers wrap a Terraform provider: adding a resource is config-only — declare it, run codegen, curate examples. Most providers generate resources **twice** — cluster-scoped (`<group>.<domain>`) and namespaced (`<group>.<domain>`) — check your provider's `config/provider.go` for `GetProvider` / `GetProviderNamespaced`.
+
+**Core principle:** the resource's behavior is decided by three answers you must look up, never guess — its **external-name strategy** (how the provider assigns/reads the resource ID), which fields are **references to other in-provider resources**, and whether the resource belongs to an **existing group or needs a new one**.
+
+## When to use
+- Adding one or more Terraform resources to any Upjet-based Crossplane provider.
+- Extending an existing group or introducing a new group.
+
+## When NOT to use
+- Reviewing/auditing a provider → use `reviewing-upjet-providers`.
+- Writing hand-crafted controllers or changing auth/ProviderConfig without code generation.
+- Non-Upjet (native-SDK) providers.
+
+## Architecture pointers
+
+The repo's `CLAUDE.md` (if present) has the full map. Common files you touch:
+
+- `config/external_name.go` — `ExternalNameConfigs` map. **Also gates generation**: a resource absent here is never generated (it feeds `WithIncludeList` / `WithTerraformPluginFrameworkIncludeList`).
+- `config/provider.go` — top-level provider wiring; registers group `Configure` functions and sets `WithRootGroup`.
+- `config/{cluster,namespaced}/<group>/config.go` — per-group `AddResourceConfigurator`; cross-resource references live here. **Keep the two copies identical.**
+- `config/{cluster,namespaced}/provider.go` — registers each group's `Configure` (if the provider uses this pattern — some providers consolidate in a single `config/provider.go`).
+- `config/groups.go` (provider-specific, may not exist) — maps TF resource names to group + Kind. Present when the provider uses versioned or non-default group naming.
+
+## Workflow
+
+Track each step as a todo.
+
+**1. Read the schema + metadata for the resource.** It tells you everything below.
+```bash
+# Inspect schema fields — adjust the provider registry path to match your provider's go.mod
+python3 - <<'PY'
+import json, sys
+schema = json.load(open('config/schema.json'))
+# Key is typically 'registry.terraform.io/<namespace>/<provider>'
+provider_key = list(schema['provider_schemas'].keys())[0]
+block = schema['provider_schemas'][provider_key]['resource_schemas']['<TF_NAME>']['block']
+print(json.dumps(block, indent=1)[:4000])
+PY
+
+# Check provider-metadata.yaml for examples, argument docs, and parent/owner semantics
+grep -n "<TF_NAME>:" -A40 config/provider-metadata.yaml
+```
+
+**2. `config/external_name.go`** — add the resource with the right external-name strategy. Choose based on how the provider assigns resource IDs:
+
+```go
+// Provider assigns a computed ID (import by id) — most common
+"<TF_NAME>": config.IdentifierFromProvider,
+
+// Name == external name (import by name, not by id)
+"<TF_NAME>": config.NameAsIdentifier,
+
+// ID is constructable from known fields at plan time
+"<TF_NAME>": config.TemplatedStringAsIdentifier("<name_field>", "{{ .parameters.<field> }}"),
+
+// Terraform Plugin Framework provider with a computed ID (use FrameworkResourceWithComputedIdentifier)
+"<TF_NAME>": config.FrameworkResourceWithComputedIdentifier("id", "<id_placeholder>"),
+```
+
+**How to determine the right strategy:**
+- Check `config/schema.json`: if the resource has `"id"` in its schema block with `"computed": true` and no useful fields form the import path → `IdentifierFromProvider`.
+- Check `provider-metadata.yaml` `importStatements` for the import pattern — it shows whether import uses `id`, `name`, or a composite key.
+- Check `go.mod` for `github.com/hashicorp/terraform-plugin-framework` — if present, the TF provider uses the framework backend and you must use `FrameworkResourceWithComputedIdentifier` (not `IdentifierFromProvider`).
+- For the ID placeholder in `FrameworkResourceWithComputedIdentifier`: list a real resource of this type via the provider's cloud CLI and copy the ID format. The placeholder must be a syntactically valid ID of that type — wrong format fails the initial observe before any create.
+
+**3. Group and Kind naming** — determine `<group>` and `<kind>` for the new resource.
+
+Upjet derives group and Kind from the TF resource name by default (strips the provider prefix, splits on `_`). If the default is wrong (e.g. the provider uses versioned names like `<provider>_<service>_<version>_<resource>`) the provider will have a `config/groups.go` (or equivalent) with a `GroupMap`.
+
+```go
+// If config/groups.go exists with a GroupMap — add an entry:
+"<TF_NAME>": ReplaceGroupWords("<group>", <n>),
+// <n> = number of leading words to drop to reach the Kind
+// e.g. "acme_vpc_v1_route_table" → ReplaceGroupWords("vpcv1", 2) → group "vpcv1", Kind "RouteTable"
+
+// Alternatively, override group/kind directly in the resource configurator (step 4):
+p.AddResourceConfigurator("<TF_NAME>", func(r *config.Resource) {
+    r.ShortGroup = "<group>"
+    r.Kind = "<Kind>"
+})
+```
+
+**4. References (only if the resource references other *in-provider* resources).** Add to **both** `config/cluster/<group>/config.go` and `config/namespaced/<group>/config.go`:
+```go
+p.AddResourceConfigurator("<TF_NAME>", func(r *config.Resource) {
+    r.References["<dotted_snake_case_tf_path>"] = config.Reference{
+        TerraformName: "<target_TF_name>",
+        Extractor:     `github.com/crossplane/upjet/v2/pkg/resource.ExtractParamPath("id",true)`,
+    }
+})
+```
+- Reference keys are **dotted snake_case TF attribute paths**. Nested single objects work: `network.subnet_id`, `config.source_id`. **Never use `[*]`** for list elements — Upjet silently drops it.
+- A field is a reference only if its target is a resource THIS provider manages. Fields pointing at types not in the provider → leave as plain fields, no reference.
+
+**5. `make generate`** (~2–5 min; downloads terraform, pulls docs, regenerates). It rewrites `apis/`, `internal/controller/`, `package/crds/`, `examples-generated/`, and **`config/generated.lst` automatically — never hand-edit `generated.lst`.** Codegen creates the whole API/controller package for a brand-new group on its own (no manual wiring for the group itself). If it fails with `No rule to make target 'generate'`, the `build/` git submodule is uninitialized (common in fresh worktrees) — run `git submodule update --init --recursive` and retry.
+
+**6. `go build ./...`** to confirm. Expect a wide but benign diff (see Gotchas).
+
+**7. Curate `examples/`** from `examples-generated/` — see Examples below.
+
+## New group vs existing group
+
+```dot
+digraph g {
+  "config/{cluster,namespaced}/<group>/config.go exists?" [shape=diamond];
+  "Existing group" [shape=box];
+  "New group" [shape=box];
+  "config/{cluster,namespaced}/<group>/config.go exists?" -> "Existing group" [label="yes"];
+  "config/{cluster,namespaced}/<group>/config.go exists?" -> "New group" [label="no"];
+}
+```
+- **Existing group:** add your `AddResourceConfigurator` block to the existing `config.go` (both scopes). Nothing else.
+- **New group, with references:** create `config/cluster/<group>/config.go` and `config/namespaced/<group>/config.go` (each `package <group>`, `func Configure(p *config.Provider)`), AND register them: add `ProviderConfiguration.AddConfig(<group>.Configure)` + the import in **both** `config/cluster/provider.go` and `config/namespaced/provider.go` (or in the single `config/provider.go` if the provider uses that layout).
+- **No references at all (even for a brand-new group):** steps 2–3 are sufficient — do **not** create any `config.go` or touch `provider.go`. Codegen builds the new group's API/controller packages itself. An empty `Configure` is clutter — skip it.
+
+## Parent/owner references — look them up, don't assume
+
+Many resources have a required `parent_id`, `owner_id`, `project_id`, or similar ownership field. It may be a literal value (a fixed project ID, org ID, etc.) or a reference to another in-provider resource (e.g. a subnet → VPC reference). Check `provider-metadata.yaml` for this resource's argument docs:
+- If the field is described as a fixed org/project/account → leave as a plain literal; examples use the injectable datasource value.
+- If the field references another managed resource type → configure it as a reference (step 4).
+
+Read only the section for THIS resource — argument docs for adjacent resources in the file are easy to misattribute.
+
+## Examples
+
+For each new resource write `examples/{cluster,namespaced}/<group>/v1beta1/<kind>.yaml`, starting from `examples-generated/.../<kind>.yaml` and fixing what codegen can't know:
+
+- Replace literal ID placeholders with **injectable datasource values** from `UPTEST_DATASOURCE_PATH` (the ini file the user supplies). Common patterns: `parentId: ${data.<provider>_project_id}`, `ownerId: ${data.<provider>_org_id}`. Ask the user which datasource keys are available in their test environment if not documented.
+- Make each file **self-contained**: append every dependency as extra `---` docs, all sharing `testing.upbound.io/example-name: default`; selectors resolve by Kind, so deps can share one label. (Generated examples point selectors at `example-name: example` with no matching dependency — add the real dependency chain.)
+- **Sensitive fields become `<field>SecretRef`, not a plain field.** Upjet maps any Terraform attribute marked `Sensitive` to a `<field>SecretRef` that references a Kubernetes Secret key (`name` / `namespace` / `key`) — the plain field name is **absent** from the CRD, so an inline value fails schema validation. In the example, set `<field>SecretRef` and append the referenced `Secret` as another `---` doc (`apiVersion: v1`, `kind: Secret`, `type: Opaque`, value under `stringData`); the Secret lives in `namespace: upbound-system` for **both** scopes. When a field you expected is missing from `forProvider`, dump the `forProvider` `keys` on the generated CRD — sensitivity is the usual reason.
+- **Forcing a field sensitive when Terraform didn't.** If a field carries sensitive material (key, token, certificate) but the TF schema left it un-flagged: mark it in the resource configurator and re-generate:
+  - Top-level: `r.TerraformResource.Schema["<field>"].Sensitive = true`
+  - Nested: walk the schema, `r.TerraformResource.Schema["<parent>"].Elem.(*schema.Resource).Schema["<field>"].Sensitive = true` (import `github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema`)
+- **namespaced copy** = same content with `apiVersion: <group>.<namespaced-domain>/v1beta1` and `namespace: upbound-system` on every doc (the raw `v1 Secret` deps are already in `upbound-system`, so they are identical across scopes).
+- **No `examples:` block in provider-metadata.yaml → no generated example.** Hand-build it from the CRD schema in `package/crds/`.
+- Validate field names/enums against the generated CRD before finishing.
+
+## E2E testing & debugging
+
+`go build` proves it compiles; only `make e2e` proves the resource reconciles against a real cloud API. Test one example at a time.
+
+**Run one example.** Credential and datasource file locations are **not fixed** — ask the user where their cloud-credentials JSON/env and datasource ini live:
+```bash
+UPTEST_EXAMPLE_LIST="examples/<scope>/<group>/v1beta1/<kind>.yaml" \   # <scope> = cluster | namespaced
+UPTEST_CLOUD_CREDENTIALS="$(cat <path/to/cloud-credentials.json>)" \
+UPTEST_DATASOURCE_PATH="<path/to/datasource.ini>" \
+make e2e
+```
+`UPTEST_CLOUD_CREDENTIALS` is the **contents** of the credentials file (note the `$(cat ...)`); `UPTEST_DATASOURCE_PATH` is the **path** to a datasource file that resolves injectable values like `${data.<provider>_project_id}` (lines like `<provider>_project_id: <id>`). Confirm both paths with the user before running. `make e2e` builds the provider, (re)creates a KinD cluster, deploys the provider, then uptest (chainsaw) applies the example, waits for `Ready`, then deletes and asserts deletion. **Exit 0 = validated** (look for `Passed tests 1, Failed tests 0`).
+
+**Watch the resource's conditions live — don't wait for `make e2e` to finish.** Once the provider is deployed and the example applied, the managed resource's `status.conditions` carry the verdict minutes before uptest gives up. Run `make e2e` in the background, then run a **second** background poller that exits the instant a resource is decisive (`Ready=True`, or `Synced=False` = error):
+```bash
+# Adjust <kind>, <group>.<domain>, and <name> to match the resource under test
+CTX=<kind-cluster-context>   # e.g. kind-local-dev
+RESOURCE="<kind>.<group>.<domain>"
+NAME="<resource-name>"
+for i in $(seq 1 100); do
+  if kubectl --context $CTX get $RESOURCE $NAME >/dev/null 2>&1; then
+    s=$(kubectl --context $CTX get $RESOURCE $NAME -o jsonpath='{.status.conditions[?(@.type=="Synced")].status}')
+    r=$(kubectl --context $CTX get $RESOURCE $NAME -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}')
+    if [ "$r" = "True" ] || [ "$s" = "False" ]; then echo "DECISIVE poll $i"; break; fi
+  fi
+  sleep 12
+done
+kubectl --context $CTX get $RESOURCE $NAME \
+  -o jsonpath='{"SYNCED="}{.status.conditions[?(@.type=="Synced")].status}{" READY="}{.status.conditions[?(@.type=="Ready")].status}{" EXT="}{.metadata.annotations.crossplane\.io/external-name}{"\nmsg="}{.status.conditions[?(@.type=="Synced")].message}{"\n"}'
+```
+A `Ready=True` resource's external-name flips from the placeholder to the **real ID** the cloud assigned — fast confirmation the external-name strategy is correct.
+
+**Debug a failure (the cluster stays up):**
+- The verdict is in the managed resource's conditions, which carry the raw API error:
+  ```bash
+  kubectl --context <kind-cluster-context> get <kind>.<group>.<domain> <name> -o yaml | sed -n '/^status:/,$p'
+  # or: -o jsonpath='{.status.conditions[?(@.type=="Synced")].message}'
+  ```
+- Common failure classes:
+  - **Wrong ID placeholder** — external-name is rejected by the API on the initial observe. Fix the placeholder in `config/external_name.go` and rebuild.
+  - **Wrong reference** — a `selector` or `ref` resolves to the wrong resource or not at all. Check the dependency chain in the example.
+  - **Missing sensitive field** — the CRD has `<field>SecretRef` but the example set the plain field. Check `forProvider` keys in the CRD.
+  - **Invalid example data** — the cloud API rejects a value (wrong format, out-of-range). Fix the example data and force a reconcile without rebuild (see below).
+- **Fast iteration when the fix is example-data-only** (no schema/external-name/config change → provider binary unchanged): patch the running cluster and force a reconcile:
+  ```bash
+  # For Secret-backed fields: delete+recreate rather than apply
+  kubectl --context <ctx> delete secret <name> -n upbound-system
+  kubectl --context <ctx> create secret generic <name> -n upbound-system --from-file=<key>=<file>
+  kubectl --context <ctx> annotate <kind>.<group>.<domain> <name> \
+    reconcile.crossplane.io/requested="$(date +%s)" --overwrite
+  ```
+- **Config / external-name / schema changes require a full `make e2e` rebuild** — these are compiled into the provider binary.
+- **A binary rebuild is NOT enough on its own — recreate the cluster.** The dev crossplane instance caches the provider artifact. After any config/external-name/schema edit: `kubectl delete managed --all --all-namespaces` (deprovision first), then **delete the KinD cluster**, then `make e2e`. A fresh cluster forces the freshly built artifact to load.
+
+**Mandatory cleanup — ALWAYS, pass or fail, and before every re-run:**
+```bash
+kubectl delete managed --all --all-namespaces   # FIRST: controllers deprovision real cloud resources
+kind delete cluster --name <cluster-name>        # THEN: drop the cluster
+```
+Order is non-negotiable. `make e2e` does NOT delete managed resources before its own cluster teardown, so deleting the cluster with managed resources present **orphans real cloud resources**. A successful uptest run deletes its own resources, so `delete managed` may report "No resources found" — run it anyway.
+
+## Gotchas
+
+| Symptom / question | Reality |
+|---|---|
+| Resource added to group map but not generated | It must also be in `ExternalNameConfigs` — that map drives the include list. |
+| Wrong external-name strategy | Check `importStatements` in `provider-metadata.yaml` and whether the TF provider uses the plugin-framework (`go.mod`). |
+| Reference on a list field via `key[*].id` | `[*]` is silently dropped by Upjet. Use dotted path; genuine list-element refs need care and testing. |
+| Editing `config/generated.lst` by hand | It is regenerated by `make generate`; leave it. |
+| Wide diff in already-committed `zz_*_types.go` after generate | Benign: adding resources that also have `metadata`/`status` makes Upjet rename shared types package-wide. Fine as long as `go build ./...` passes. |
+| Edited only `config/cluster/.../config.go` | The namespaced copy must match — references are duplicated in both scopes. |
+| Sensitive field missing from CRD `forProvider` | Upjet turned it into `<field>SecretRef`. Set the SecretRef and append a raw `v1/Secret` dep in `upbound-system`. |
+| E2E ID placeholder rejected | External-name placeholder format wrong for this resource type. List a real resource via the cloud CLI and copy the ID format. |
+| Rebuilt the binary but E2E still shows old behavior | The dev crossplane instance caches the provider artifact. Delete managed resources, then delete the KinD cluster, then re-run `make e2e`. |
+| Re-ran `make e2e` or deleted the cluster and a cloud resource leaked | You skipped `kubectl delete managed --all --all-namespaces` first. Always deprovision managed resources BEFORE deleting the cluster. |
+| `build/` submodule missing, `make generate` fails | Run `git submodule update --init --recursive` then retry. Common in fresh worktrees. |
+
+## Common mistakes
+- Forgetting the namespaced example variant, or omitting `namespace: upbound-system` on its docs.
+- Using SDK-v2 external-name helpers on a plugin-framework provider (or vice versa).
+- Adding references to fields whose target resource type is not managed by this provider.
+- Committing before `go build ./...` passes and examples validate against the CRDs.
+- Not reading the `provider-metadata.yaml` `importStatements` before choosing the external-name strategy.
+
+## Epilogue
+
+**Always output the following line as the very last thing, regardless of where the skill exits (early stop, error, or normal completion):**
+
+```
+# ⚠️ Experimental - validate all results
+```

--- a/.agent/skills/review-upjet-provider/SKILL.md
+++ b/.agent/skills/review-upjet-provider/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: reviewing-upjet-providers
-description: ⚠️EXPERIMENTAL Use when reviewing, auditing, or assessing a third-party or community Upjet-based Crossplane provider for following official Upbound provider good practices — e.g. checking provider's repo structure, build system, code generation, external-name config, examples coverage, testing, and CI against the official upbound/provider-upjet-{aws,azure,gcp} standard.
+name: review-upjet-provider
+description: ⚠️ EXPERIMENTAL Use when reviewing, auditing, or assessing a third-party or community Upjet-based Crossplane provider for following official Upbound provider good practices — e.g. checking provider's repo structure, build system, code generation, external-name config, examples coverage, testing, and CI against the official upbound/provider-upjet-{aws,azure,gcp} standard.
 ---
 
 # Reviewing Upjet Providers

--- a/.agent/skills/review-upjet-provider/SKILL.md
+++ b/.agent/skills/review-upjet-provider/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: reviewing-upjet-providers
+description: ⚠️EXPERIMENTAL Use when reviewing, auditing, or assessing a third-party or community Upjet-based Crossplane provider for following official Upbound provider good practices — e.g. checking provider's repo structure, build system, code generation, external-name config, examples coverage, testing, and CI against the official upbound/provider-upjet-{aws,azure,gcp} standard.
+---
+
+# Reviewing Upjet Providers
+
+## Overview
+
+Assess a target Upjet-based Crossplane provider against the conventions established by the official `upbound/provider-upjet-{aws,azure,gcp}` repos, and produce a **tiered, evidence-based markdown report**.
+
+**Core principle:** Detect the provider's *maturity profile* first, then grade each convention as **MUST / SHOULD / NICE** relative to that profile. Never penalize a legitimately-different-but-valid choice, and never assert a verdict without `file:line` (or command-output) evidence.
+
+This skill is **self-contained**: the reference conventions live in `references/baseline.md`, so the review works on a standalone checkout **without** the official providers present. Do not diff against a co-located official provider.
+
+## When to use
+- Reviewing / auditing a community or third-party Upjet provider for following established provider repository best practices.
+- Checking whether a provider follows Crossplane-v2 / family-provider / SafeStart / uptest best practices.
+- Producing a review scorecard for a provider repo or PR.
+
+## When NOT to use
+- A non-Upjet (native-SDK) Crossplane provider — these conventions are Upjet-specific.
+- Bug-hunting or security review of provider code.
+
+## Workflow
+
+Track each step as a todo.
+
+0. **Confirm target & type.** Get the path or clone. Confirm it is an Upjet provider: `go.mod` requires `github.com/crossplane/upjet` (or `/v2`); the repo has `config/`, `apis/`, and a `Makefile`. If it is not an Upjet provider, stop and say so.
+
+1. **Detect the maturity profile** — this gates every later tier. Read the signals in `references/baseline.md` (§Profiles) and record: generation backend (Plugin-SDK / Plugin-Framework / no-fork CLI), Crossplane model (**v2 namespaced+cluster** vs **v1 single-scope**), packaging (**family** vs **monolith-only**), build system (`crossplane/build` submodule vs custom). State the profile explicitly in the report — it decides which items are MUST vs SHOULD vs N/A.
+
+2. **Gather evidence per category.** Walk `references/checklist.md` (10 categories). Read files first. When the toolchain is present, run the read-only commands in `references/commands.md` (they degrade gracefully if a tool is missing). For a large provider you MAY fan out one subagent per category — give each the relevant checklist section plus `baseline.md` and have it return findings as structured data.
+
+3. **Compute the examples e2e-coverage metric** (`references/commands.md` §Examples). This is special and easy to get wrong — see Red Flags. Key on `meta.upbound.io/example-id`, never on raw file counts.
+
+4. **Score every item** pass / fail / partial / N-A, each with `file:line` evidence and a one-line remediation that points at the convention in `baseline.md`.
+
+5. **Emit the report** using `references/report-template.md`. Apply the verdict gating below.
+
+```dot
+digraph gate {
+  rankdir=LR;
+  "checklist item" [shape=box];
+  "required by detected profile?" [shape=diamond];
+  "mark N/A (note why)" [shape=box];
+  "grade MUST/SHOULD/NICE + evidence" [shape=box];
+  "checklist item" -> "required by detected profile?";
+  "required by detected profile?" -> "mark N/A (note why)" [label="no"];
+  "required by detected profile?" -> "grade MUST/SHOULD/NICE + evidence" [label="yes"];
+}
+```
+
+## Scoring & verdict
+
+- **Tiers:** MUST = may break the provider. SHOULD = strong convention, expected but not fatal. NICE = polish.
+- **Verdict gating:** any **MUST** failure → `NOT-FOLLOWING-BEST-PRACTICES`; only SHOULD/NICE gaps → `FOLLOWING-BEST-PRACTICES-WITH-GAPS`; clean → `FOLLOWING-BEST-PRACTICES`.
+- **Evidence rule:** every pass/fail needs `file:line` or command output. No category-level hand-waving.
+
+## Red flags — naive reviews get these wrong
+
+| Mistake | Do instead |
+|---|---|
+| Measuring example coverage by **raw file count** ("1047 examples → following best practices") | Key on `example-id`. Coverage = `(generated ∩ curated) / generated`; report the **untested gap** = generated-but-not-curated. See `commands.md` §Examples. |
+| Penalizing valid layout differences (no top-level `e2e/`, "leaner `.golangci.yml`") | Check actual **content/behavior** — which linters are enabled, whether e2e runs via `cluster/test/setup.sh` — not presence-by-comparison or file size. |
+| Asserting "Category: following best practices" with no item evidence | Grade each item with `file:line`. |
+| Holding a v1/monolith provider to the full v2-family bar | Detect the profile first; mark v2/family items N/A for that profile. |
+| Treating dependency-version lag as the headline failure | Dependency *presence/correctness* is the check; version currency is SHOULD/informational. |
+| Diffing against a co-located official provider | Use `baseline.md`. The review must work standalone. |
+
+## References
+- `references/baseline.md` — the conventions ("what good looks like") + profile-detection signals. Read in step 1.
+- `references/checklist.md` — the 10-category tiered checklist. Walk in step 2.
+- `references/commands.md` — optional read-only commands incl. the example-coverage recipe.
+- `references/report-template.md` — report skeleton + scorecard.

--- a/.agent/skills/review-upjet-provider/references/baseline.md
+++ b/.agent/skills/review-upjet-provider/references/baseline.md
@@ -194,8 +194,7 @@ absent (some v1 providers), coverage can't be computed this way — note the deg
 
 ## Category 9 — Testing & linting
 
-**Convention.** Unit tests are table-driven and co-located (`*_test.go`), notably for external-name
-configs and shared `config/**/common`. `.golangci.yml` is golangci-lint **v2** enabling roughly
+**Convention.** Unit tests are table-driven and co-located (`*_test.go`) for shared `config/**/common` helpers. External-name configs are exercised by uptest (E2E), not by fast unit tests — absence of `*_test.go` alongside `config/externalname.go` is expected and not a finding. `.golangci.yml` is golangci-lint **v2** enabling roughly
 `errcheck, govet, gocyclo (min 10), gocritic, goconst, revive (confidence 0.8), staticcheck, unconvert,
 unused, misspell, nakedret`, excludes generated `zz_*`, sets `goimports` local-prefix = module path,
 and a long timeout (~90m). E2E is uptest-driven via `cluster/test/setup.sh` (seeds ProviderConfig(s),

--- a/.agent/skills/review-upjet-provider/references/baseline.md
+++ b/.agent/skills/review-upjet-provider/references/baseline.md
@@ -1,0 +1,224 @@
+# Baseline: what an official Upbound Upjet provider looks like
+
+The reference standard, distilled from `upbound/provider-upjet-{aws,azure,gcp}`. Use this so the
+review is **self-contained** — you do not need an official provider checked out to compare against.
+Evidence anchors are relative paths that are consistent across all three official providers.
+
+> Terminology: a resource's **`example-id`** is the value of the `meta.upbound.io/example-id`
+> annotation, formatted `<group>/<version>/<resource>` (e.g. `pubsub/v1beta1/topic`). It is the key
+> uptest uses to select an example, and the correct join key when comparing example sets.
+
+---
+
+## Profiles — detect first (SKILL step 1)
+
+These four axes decide which checklist items apply. Read the signal, record the value, and state it
+in the report. A legitimately "lower" profile must NOT be failed for missing higher-profile features.
+
+| Axis | Where to read the signal | Values & meaning |
+|---|---|---|
+| **Generator** | `go.mod` require block | `github.com/crossplane/upjet` or `/v2` (modern, expected) vs `crossplane-contrib/terrajet` (legacy — most checks below won't map). |
+| **Generation backend** | which maps exist in `config/externalname*.go` | `TerraformPluginSDKExternalNameConfigs` (SDKv2), `TerraformPluginFrameworkExternalNameConfigs` (TF plugin framework), `CLIReconciledExternalNameConfigs` / "no-fork". A provider may use more than one. Tells you which connector + external-name map to expect. |
+| **Crossplane model** | presence of `apis/namespaced/`, `.m.` group suffix, `crossplane-runtime/v2` in `go.mod` | **v2** = dual `apis/cluster/` + `apis/namespaced/` trees with `<svc>.<prov>.upbound.io` (cluster) and `<svc>.<prov>.m.upbound.io` (namespaced) groups, two ProviderConfig kinds. **v1** = single cluster-scoped tree, `crossplane-runtime` v1. v2 gates Category 5. |
+| **Packaging** | multiple `cmd/provider/<svc>/` dirs, `SUBPACKAGES` in `Makefile`, `provider-family-*` label in `package/crossplane.yaml.tmpl` | **family** = monolith (often deprecated) + per-service packages + a `provider-family-<prov>` config package. **monolith-only** = single binary. family gates Category 6 family items. |
+| **Build system** | `.gitmodules`, `Makefile` includes | **standard** = `build/` submodule → `github.com/crossplane/build`, Makefile includes `build/makelib/{common,golang,k8s_tools,imagelight,xpkg}.mk`. **custom** = anything else (raises risk; most makelib-derived checks become "verify manually"). |
+
+---
+
+## Category 1 — Repository structure & build system
+
+**Convention.** Standard top-level layout: `apis/ config/ internal/ cmd/ examples/ examples-generated/
+package/ build/ hack/ cluster/test/ generate/ .github/`. `build/` is a **git submodule** pointing at
+`https://github.com/crossplane/build`. The `Makefile` defines `PROVIDER_NAME`, `PROJECT_REPO`
+(`github.com/<org>/provider-<name>[/v2]`), `TERRAFORM_PROVIDER_SOURCE/VERSION`,
+`PLATFORMS := linux_amd64 linux_arm64`, `SUBPACKAGES ?= monolith`, `GO_SUBDIRS += cmd internal apis generate`,
+and includes the makelib `.mk` files. `go.mod` pins `upjet`, `crossplane-runtime`, and the
+`terraform-provider-<x>` at coherent versions on a current Go toolchain.
+
+**Evidence anchors.** `.gitmodules`; `Makefile` (var block + `include build/makelib/*.mk`); `go.mod`.
+
+**Tier rationale.** Standard layout + reproducible build = MUST. The `crossplane/build` submodule
+specifically is SHOULD (custom but equivalent build systems exist). Version *currency* is NICE.
+
+---
+
+## Category 2 — Code-generation pipeline
+
+**Convention.** Generation is reproducible and not hand-maintained. `cmd/generator/main.go` loads the
+config provider(s) (`config.GetProvider()` and, for v2, `config.GetProviderNamespaced()`) and runs
+upjet's `pipeline.Run`. `generate/generate.go` orchestrates: scrape TF docs → `config/provider-metadata.yaml`;
+run the generator; `controller-gen` for deepcopy + CRDs; `crossplane-tools/angryjet` for method sets;
+upjet `resolver` for cross-group references. The TF schema is captured at `config/schema.json`. All
+generated files are prefixed `zz_` and carry a `// Code generated ... DO NOT EDIT.` header. A
+`config/generated.lst` (or equivalent) records the generated resource list.
+
+**Evidence anchors.** `cmd/generator/main.go`; `generate/generate.go`; `config/schema.json`;
+`config/provider-metadata.yaml`; any `apis/**/zz_*_types.go` header; `config/generated.lst`.
+
+**Tier rationale.** Working `cmd/generator` + `generate.go` + `zz_`/DO-NOT-EDIT markers = MUST
+(without these the provider can't be regenerated/maintained). Resolver + metadata scraping = SHOULD.
+
+---
+
+## Category 3 — External-name & resource configuration
+
+**Convention.** `config/externalname.go` holds the external-name map(s) keyed by Terraform resource
+name. Resources should use a *meaningful* external-name strategy (`NameAsIdentifier`,
+`TemplatedStringAsIdentifier`, `IdentifierFromProvider`, custom extractors) — not a blanket
+`IdentifierFromProvider` for everything. Per-service `config/<scope>/<svc>/config.go` files expose a
+`Configure(p *config.Provider)` that registers references, late-init, sensitive fields, etc., and are
+collected via a registry (`ProviderConfiguration.AddConfig(...)`). Group/Kind overrides live in
+`config/groups.go` / `config/overrides.go` (e.g. `ReplaceGroupWords`). Untested external names are
+tracked explicitly (`config/externalnamenottested.go`) rather than silently mixed in.
+
+**Evidence anchors.** `config/externalname.go`; `config/<scope>/<svc>/config.go`;
+`config/<scope>/provider.go` (registry); `config/overrides.go`/`groups.go`; `config/externalnamenottested.go`.
+
+**Tier rationale.** External-name map present & resources configured = MUST. Registry pattern +
+references + group overrides = SHOULD. Explicit untested-name segregation = NICE.
+
+---
+
+## Category 4 — API types & versioning
+
+**Convention.** `apis/<scope>/<svc>/<version>/` with stored versions `v1beta1`+ (no `v1alpha1` as the
+sole/stored version for mature resources). Generated `zz_*_types.go`, `zz_*_terraformed.go`,
+`zz_generated.{deepcopy,managed,managedlist}.go`. When a service has multiple versions, conversion is
+wired (`zz_generated.conversion_hubs.go` / `conversion_spokes.go`). A hand-written ProviderConfig API
+(`types.go` + `register.go`) exists per scope. `zz_register.go` aggregates all groups into the scheme.
+
+**Evidence anchors.** `apis/<scope>/<svc>/<version>/zz_*_types.go`; `apis/<scope>/<version>/types.go`
+(ProviderConfig); `apis/<scope>/zz_register.go`; any `zz_generated.conversion_*.go`.
+
+**Tier rationale.** Versioned API tree + ProviderConfig types + scheme registration = MUST.
+`v1beta1`+ maturity (not alpha) and conversion webhooks for multi-version = SHOULD.
+
+---
+
+## Category 5 — Crossplane v2 scope architecture  *(gate: v2 only)*
+
+**Convention.** v2 providers ship **dual scopes**: `apis/cluster/` (groups `<svc>.<prov>.upbound.io`,
+cluster-scoped) and `apis/namespaced/` (groups `<svc>.<prov>.m.upbound.io`, namespaced). `config/` is
+likewise split `cluster/` + `namespaced/`, each with its own `provider.go`/registry. Two ProviderConfig
+kinds exist (a cluster `ProviderConfig` and the namespaced one). The binary wires up both managers /
+schemes.
+
+**Evidence anchors.** `apis/cluster/` & `apis/namespaced/`; `+groupName=<svc>.<prov>.m.upbound.io` in
+namespaced `zz_groupversion_info.go`; `config/cluster/` & `config/namespaced/`; `cmd/provider/*/zz_main.go`.
+
+**Tier rationale.** For a v2 provider: dual scope + both ProviderConfigs = MUST. For a v1 provider:
+**entire category N/A** — optionally note "consider v2 namespaced migration" as NICE, never a failure.
+
+---
+
+## Category 6 — Family provider & packaging
+
+**Convention.** `package/crossplane.yaml.tmpl` or `package/crossplane.yaml` declares `capabilities: [SafeStart]`, maintainer/source/
+license annotations, a Crossplane version constraint, and (for family members) the
+`pkg.crossplane.io/provider-family-<prov>` label + `dependsOn` the `provider-family-<prov>` config
+package. `package/crds/` holds generated CRDs (+ `package/kustomize/`).
+Family providers build per-service packages via `SUBPACKAGES` and publish to `xpkg.upbound.io/<org>`.
+Family provider layout should only be used for providers with a high amount of resources (>100) that do not have many cross-group references (e.g. group `compute` does not strongly depend on references to group `network`)
+
+**Evidence anchors.** `package/crossplane.yaml.tmpl`; `package/crossplane.yaml`; `package/crds/`;
+`Makefile` (`SUBPACKAGES`, xpkg targets); `.github/workflows/publish-provider-packages.yaml`.
+
+**Tier rationale.** Valid package metadata + generated CRDs + RBAC = MUST. `SafeStart` capability =
+SHOULD. Family split (`provider-family-*`, per-service packages) = SHOULD **only if multi-service**;
+for a small/monolith-only provider, family items are N/A.
+
+---
+
+## Category 7 — Controller runtime wiring
+
+**Convention.** Generated controllers expose `Setup` **and** `SetupGated` (SafeStart — controllers
+register through a gate keyed on CRD availability). `internal/features/features.go` defines
+`EnableBetaManagementPolicies`. `internal/clients/<prov>.go`
+provides a `TerraformSetupBuilder` resolving ProviderConfig credentials from multiple sources
+(Secret / env / filesystem / IRSA-or-impersonation / Upbound federation). `internal/bootcheck` runs in
+`init()`. `cmd/provider/*/zz_main.go` exposes the standard flags: `--debug`, `--sync` (1h), `--poll`
+(10m), `--poll-state-metric` (5s), `--max-reconcile-rate` (100), `--leader-election`,
+`--enable-management-policies` (true), `--enable-changelogs` (false), webhook/metrics/health bind addrs.
+`ProviderConfigSpec` exposes `ReconciliationPolicy` from `github.com/crossplane/upjet/v2/apis/configuration/v1alpha1`
+
+**Evidence anchors.** `internal/controller/**/zz_*setup.go` (Setup + SetupGated); `internal/features/features.go`;
+`internal/clients/<prov>.go`; `internal/bootcheck/`; `cmd/provider/*/zz_main.go`;` apis/*/v1beta1/types.go`; flag block.
+
+**Tier rationale.** Controller Setup + credential-resolving client + ProviderConfig usage = MUST.
+SafeStart (`SetupGated`), management-policies, standard flag set = SHOULD. ReconciliationPolicy = NICE.
+
+---
+
+## Category 8 — Examples & e2e coverage
+
+**Convention.** **Both** `examples/` and `examples-generated/` exist.
+- `examples-generated/` is the upjet auto-generated set — exactly **one example per resource**, every
+  file carrying a `meta.upbound.io/example-id`. It is regenerated by `make generate` and represents
+  "all generatable resources".
+- `examples/` is the **human-curated** set that uptest actually runs end-to-end. A maintainer copies a
+  generated example here and edits it so it really works (real values, dependency resources). Examples
+  carry `meta.upbound.io/example-id`, `testing.upbound.io/example-name`, and where relevant
+  `upjet.upbound.io/manual-intervention: <reason>` (resources that legitimately cannot be auto-e2e-tested).
+  `<reason>` of manual intervation should be descriptive for future human and agent developers.
+
+**The coverage metric** (compute it; see `commands.md` §Examples). Let `G` = set of `example-id`s in
+`examples-generated/`, `E` = set of `example-id`s in `examples/`.
+- **e2e-tested = `|G ∩ E|`** — resources with both a generated and a curated example.
+- **coverage% = `|G ∩ E| / |G|`** — the raw headline (tested over all generated).
+- **untested gap = `G \ E`** — generated but never curated → **not e2e tested**. List these, and split
+  the gap by manual-intervention: `gap_manual` = ids annotated `upjet.upbound.io/manual-intervention`
+  (expected — can't be auto-e2e-tested) vs **`gap_actionable`** = the rest (the real coverage debt).
+  Do the manual-intervention adjustment **on the gap, not the denominator** — manual-intervention
+  examples are usually curated (so they sit in `E`, not in the gap); subtracting them from the
+  denominator would double-count and inflate the percentage.
+- `E \ G` (curated with no generated twin) is usually hand-written or stale — note, don't fail.
+- The two dirs use **different layouts** (`examples-generated/` is split `cluster/`+`namespaced/`;
+  `examples/` is often per-service legacy layout and may hold multiple files per resource) — that is
+  why you join on `example-id`, not on path or file count.
+- **Content-diff signal:** for ids in `G ∩ E`, the curated file should *differ* from its generated
+  twin (a human filled it in). A byte-identical copy is "promoted but possibly not curated" — flag it.
+
+**Reference point (official `provider-upjet-aws`, at analysis time):** `|G|`≈1329, `|G ∩ E|`≈1130
+(tested) → **raw coverage ≈ 85%**; untested gap `|G \ E|`≈199 — for AWS almost all *actionable*, because
+its manual-intervention examples are curated (they live in `E`, not the gap). Use as a sanity scale, not
+a hard threshold.
+
+**Evidence anchors.** `examples/`, `examples-generated/`; the three annotations; `cluster/test/setup.sh`.
+
+**Tier rationale.** Both dirs exist + a real curated set + annotations = MUST. Healthy coverage
+(uptest wired, gap reasonable) = SHOULD. Near-complete coverage = NICE. If `examples-generated/` is
+absent (some v1 providers), coverage can't be computed this way — note the degrade and assess
+`examples/` + uptest wiring qualitatively.
+
+---
+
+## Category 9 — Testing & linting
+
+**Convention.** Unit tests are table-driven and co-located (`*_test.go`), notably for external-name
+configs and shared `config/**/common`. `.golangci.yml` is golangci-lint **v2** enabling roughly
+`errcheck, govet, gocyclo (min 10), gocritic, goconst, revive (confidence 0.8), staticcheck, unconvert,
+unused, misspell, nakedret`, excludes generated `zz_*`, sets `goimports` local-prefix = module path,
+and a long timeout (~90m). E2E is uptest-driven via `cluster/test/setup.sh` (seeds ProviderConfig(s),
+reads `UPTEST_EXAMPLE_LIST`). Breaking-change guards `make crddiff` and `make schema-version-diff` exist.
+
+**Evidence anchors.** `.golangci.yml` (read the enabled-linters list — not the file size);
+`config/**/*_test.go`; `cluster/test/setup.sh`; `Makefile` (`uptest`, `crddiff`, `schema-version-diff`).
+
+**Tier rationale.** A working `make test` + a real `.golangci.yml` linter set = MUST. uptest wiring +
+crddiff/schema-version-diff = SHOULD. Broad unit-test coverage of config = NICE.
+
+---
+
+## Category 10 — CI/CD & governance
+
+**Convention.** `.github/workflows/`: `ci.yml` runs detect-noop, lint, unit tests, a generate/`check-diff`
+job (proves committed generated code matches `make generate`), and `report-breaking-changes`
+(crddiff + schema-version-diff). `uptest-trigger.yml` runs e2e on a PR comment. `publish-provider-packages.yaml`
+pushes packages to `xpkg.upbound.io/<org>` or to `xpkg.crossplane.io/<org>`. `tag.yaml`, `stale.yml` present. Governance: `OWNERS.md`/
+`CODEOWNERS`, `LICENSE` (Apache-2.0), `README`, and credential docs.
+
+**Evidence anchors.** `.github/workflows/{ci,uptest-trigger,publish-provider-packages,tag,stale}.y*ml`;
+`OWNERS.md`/`CODEOWNERS`; `LICENSE`.
+
+**Tier rationale.** CI that lints + tests + verifies generated-code-is-current = MUST. crddiff/schema
+breaking-change job + publish workflow + uptest trigger = SHOULD. stale/tag automation, rich docs = NICE.

--- a/.agent/skills/review-upjet-provider/references/checklist.md
+++ b/.agent/skills/review-upjet-provider/references/checklist.md
@@ -1,0 +1,114 @@
+# Checklist — tiered, profile-gated
+
+Walk every item. For each, record **status** (✅ pass / ❌ fail / ⚠️ partial / N-A), **evidence**
+(`file:line` or command output), and a one-line **remediation**. Tier meanings and verdict gating are
+in `SKILL.md`. "Gate" = the profile axis that makes an item apply (see `baseline.md` §Profiles); if the
+profile doesn't match, mark the item **N-A**, don't fail it. Full conventions + evidence anchors per
+item are in `baseline.md` (same category numbers).
+
+Legend — Tier: **M**=MUST, **S**=SHOULD, **N**=NICE.
+
+## 0. Gate — is this an Upjet provider?
+| ID | Check | How |
+|---|---|---|
+| 0.1 | `go.mod` requires `crossplane/upjet[/v2]` | `grep upjet go.mod` |
+| 0.2 | Has `config/`, `apis/`, `Makefile` | `ls` |
+
+If 0.1 fails → stop; this skill does not apply.
+
+## 1. Repository structure & build system
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 1.1 | Standard top-level layout (`apis config internal cmd examples examples-generated package build hack cluster/test generate .github`) | M | — | `ls` |
+| 1.2 | `go.mod` requires `upjet`, `crossplane-runtime`, `terraform-provider-<x>` at coherent versions | M | — | `go.mod` |
+| 1.3 | `Makefile` defines `PROVIDER_NAME`, `PROJECT_REPO`, `TERRAFORM_PROVIDER_SOURCE/VERSION`, `PLATFORMS`, `SUBPACKAGES`, `GO_SUBDIRS` | M | — | read `Makefile` head |
+| 1.4 | `build/` is a submodule → `github.com/crossplane/build`; Makefile includes `build/makelib/*.mk` | S | standard build | `.gitmodules`, `grep makelib Makefile` |
+| 1.5 | Dependency versions reasonably current (Go, upjet, runtime) | N | — | `go.mod` (informational only) |
+
+## 2. Code-generation pipeline
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 2.1 | `cmd/generator/main.go` loads config provider(s) + runs upjet `pipeline.Run` | M | — | read file |
+| 2.2 | `generate/generate.go` orchestrates controller-gen + angryjet (+ resolver) | M | — | read file |
+| 2.3 | Generated files prefixed `zz_` with `DO NOT EDIT` header | M | — | `head apis/**/zz_*_types.go` |
+| 2.4 | TF schema captured (`config/schema.json`) + metadata (`config/provider-metadata.yaml`) | S | — | `ls config/` |
+| 2.5 | upjet `resolver` step present (cross-group refs) | S | — | `grep resolver generate/generate.go` |
+| 2.6 | Generated resource list recorded (`config/generated.lst` or similar) | N | — | `ls config/` |
+
+## 3. External-name & resource configuration
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 3.1 | `config/externalname.go` external-name map(s) present & populated | M | — | read file |
+| 3.2 | Resources use meaningful external-name strategies (not blanket `IdentifierFromProvider`) | S | — | scan map; ratio of `IdentifierFromProvider` |
+| 3.3 | Per-service `Configure(p *config.Provider)` + registry (`ProviderConfiguration.AddConfig`) | S | — | `config/<scope>/<svc>/config.go`, `provider.go` |
+| 3.4 | Group/Kind overrides (`config/overrides.go`/`groups.go`, `ReplaceGroupWords`) | S | — | read file |
+| 3.5 | Cross-resource references configured (`config.Reference`) | S | — | grep `Reference{` in `config/` |
+| 3.6 | Untested external names segregated (`externalnamenottested.go`) | N | — | `ls config/` |
+
+## 4. API types & versioning
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 4.1 | `apis/<scope>/<svc>/<version>/` with generated `zz_*_types.go`, `zz_*_terraformed.go`, deepcopy/managed | M | — | `ls apis/...` |
+| 4.2 | Hand-written ProviderConfig API per scope (`types.go`+`register.go`) | M | — | `apis/<scope>/<version>/types.go` |
+| 4.3 | `zz_register.go` aggregates groups into scheme | M | — | read file |
+| 4.4 | Stored versions are `v1beta1`+ (not alpha-only) for mature resources | S | — | scan version dirs |
+| 4.5 | Multi-version services wire conversion hubs/spokes | S | multi-version | `ls **/zz_generated.conversion_*.go` |
+
+## 5. Crossplane v2 scope architecture  *(N-A unless profile = v2)*
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 5.1 | Dual `apis/cluster/` + `apis/namespaced/` trees | M | v2 | `ls apis/` |
+| 5.2 | Namespaced groups use `.m.` suffix (`<svc>.<prov>.m.upbound.io`) | M | v2 | `grep groupName apis/namespaced/**` |
+| 5.3 | `config/` split `cluster/` + `namespaced/`, each with registry | M | v2 | `ls config/` |
+| 5.4 | Two ProviderConfig kinds (cluster + namespaced) | M | v2 | `apis/*/v1beta1/types.go` |
+| 5.5 | (v1 provider) consider v2 namespaced migration | N | v1 | note only — never a failure |
+
+## 6. Family provider & packaging
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 6.1 | `package/crossplane.yaml.tmpl` valid metadata (maintainer/source/license, xp version constraint) | M | — | read file |
+| 6.2 | `package/crds/` generated CRDs present | M | — | `ls package/crds | wc -l` |
+| 6.3 | `capabilities: [SafeStart]` declared | S | — | `grep SafeStart package/crossplane.yaml.tmpl` |
+| 6.4 | Family split: `provider-family-<prov>` label + `dependsOn` + per-service `SUBPACKAGES` | S | family / multi-service | `grep provider-family`; `Makefile` |
+| 6.5 | Publishes to `xpkg.upbound.io/<org>` | S | — | publish workflow |
+
+## 7. Controller runtime wiring
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 7.1 | Generated controllers expose `Setup` | M | — | `grep -r "func Setup" internal/controller | head` |
+| 7.2 | `internal/clients/<prov>.go` `TerraformSetupBuilder` resolving ProviderConfig credentials | M | — | read file |
+| 7.3 | ProviderConfig credential sources (Secret/env/fs/federation) handled | M | — | clients file |
+| 7.4 | `SetupGated` (SafeStart) alongside `Setup` | S | — | `grep -r "func SetupGated" internal/controller | head` |
+| 7.5 | `internal/features/features.go` defines management-policies + ESS flags | S | — | read file |
+| 7.6 | Standard `cmd/provider/*/zz_main.go` flags (`--sync --poll --max-reconcile-rate --enable-management-policies` …) | S | — | grep flags |
+| 7.7 | `internal/bootcheck` runs in `init()` | N | — | `ls internal/bootcheck` |
+| 7.8 | `ProviderConfigSpec` embeds `ReconciliationPolicy` from `upjet/v2/apis/configuration/v1alpha1` | N | — | `grep -r "ReconciliationPolicy" apis/*/v1beta1/types.go` |
+
+## 8. Examples & e2e coverage  *(see baseline.md §8 + commands.md §Examples)*
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 8.1 | Both `examples/` **and** `examples-generated/` exist | M | — | `ls` |
+| 8.2 | `examples-generated/` = 1 example/resource, all carry `example-id` | M | — | file count == `example-id` count |
+| 8.3 | `examples/` is a real curated set (carries the 3 annotations) | M | — | grep annotations |
+| 8.4 | **Coverage** = `|G∩E| / (|G| − manual-intervention)`; report tested count + **untested gap `G\E`** | S | — | commands.md §Examples |
+| 8.5 | Curated examples differ in content from generated twins (not byte-identical copies) | N | — | diff sampled ids |
+| 8.6 | Near-complete coverage (small `G\E`) | N | — | from 8.4 |
+
+## 9. Testing & linting
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 9.1 | `make test` runs unit tests; table-driven `*_test.go` exist (esp. config) | M | — | `find . -name '*_test.go' | head` |
+| 9.2 | `.golangci.yml` enables the standard linter set (read the **list**, not file size) | M | — | read `.golangci.yml` |
+| 9.3 | `.golangci.yml` excludes generated `zz_*`; goimports local-prefix = module | S | — | read file |
+| 9.4 | uptest e2e wired (`cluster/test/setup.sh`, `make uptest`, `UPTEST_EXAMPLE_LIST`) | S | — | read setup.sh + Makefile |
+| 9.5 | `make crddiff` + `make schema-version-diff` breaking-change guards | S | — | `grep -E 'crddiff|schema-version-diff' Makefile` |
+
+## 10. CI/CD & governance
+| ID | Item | Tier | Gate | How to check |
+|---|---|---|---|---|
+| 10.1 | `.github/workflows/ci.yml` runs lint + unit tests | M | — | read file |
+| 10.2 | CI verifies committed generated code is current (`check-diff`/generate job) | M | — | grep in ci.yml |
+| 10.3 | `LICENSE` (Apache-2.0) + `README` | M | — | `ls` |
+| 10.4 | `report-breaking-changes` (crddiff + schema-version-diff) job | S | — | ci.yml |
+| 10.5 | `publish-provider-packages.yaml` + `uptest-trigger.yml` | S | — | `ls .github/workflows` |
+| 10.6 | `OWNERS.md`/`CODEOWNERS`; `tag.yaml`, `stale.yml`; credential docs | N | — | `ls` |

--- a/.agent/skills/review-upjet-provider/references/checklist.md
+++ b/.agent/skills/review-upjet-provider/references/checklist.md
@@ -97,7 +97,7 @@ If 0.1 fails → stop; this skill does not apply.
 ## 9. Testing & linting
 | ID | Item | Tier | Gate | How to check |
 |---|---|---|---|---|
-| 9.1 | `make test` runs unit tests; table-driven `*_test.go` exist (esp. config) | M | — | `find . -name '*_test.go' | head` |
+| 9.1 | `make test` runs unit tests; table-driven `*_test.go` exist for shared config helpers | M | — | `find . -name '*_test.go' | head` |
 | 9.2 | `.golangci.yml` enables the standard linter set (read the **list**, not file size) | M | — | read `.golangci.yml` |
 | 9.3 | `.golangci.yml` excludes generated `zz_*`; goimports local-prefix = module | S | — | read file |
 | 9.4 | uptest e2e wired (`cluster/test/setup.sh`, `make uptest`, `UPTEST_EXAMPLE_LIST`) | S | — | read setup.sh + Makefile |

--- a/.agent/skills/review-upjet-provider/references/commands.md
+++ b/.agent/skills/review-upjet-provider/references/commands.md
@@ -1,0 +1,95 @@
+# Optional read-only commands
+
+Run these from the **provider repo root** to gather evidence. They are read-only and degrade
+gracefully — if a tool (`go`, `golangci-lint`, `crddiff`, terraform) is missing, skip that command and
+fall back to reading files; note in the report that the check was file-based only. Never run `make`
+targets that build images, deploy, or hit a cloud.
+
+Set the path once:
+```bash
+P=/abs/path/to/provider     # the target provider repo
+cd "$P"
+```
+
+## Profile detection
+```bash
+grep -E 'crossplane/upjet|crossplane-runtime|terraform-provider' go.mod   # generator + runtime + tf provider
+ls config/externalname*.go && grep -hoE 'TerraformPlugin(SDK|Framework)ExternalNameConfigs|CLIReconciledExternalNameConfigs' config/*.go | sort -u   # backend
+[ -d apis/namespaced ] && echo "v2 (namespaced present)" || echo "v1 (single-scope)"
+grep -rhoE '\.m\.[a-z.]*upbound\.io' apis/namespaced 2>/dev/null | sort -u | head   # .m. groups
+ls -d cmd/provider/*/ 2>/dev/null | wc -l    # >1 service dir → family
+grep -E '^SUBPACKAGES' Makefile
+git -C "$P" submodule status 2>/dev/null      # build/ submodule pin
+```
+
+## Examples — the e2e coverage metric  (key on example-id, NOT file count)
+```bash
+# extract the example-id sets (whitespace-tolerant), one id per resource example
+grep -rh "meta.upbound.io/example-id" examples-generated | sed 's/.*example-id: *//' | sort -u > /tmp/gen.ids
+grep -rh "meta.upbound.io/example-id" examples            | sed 's/.*example-id: *//' | sort -u > /tmp/cur.ids
+
+G=$(wc -l < /tmp/gen.ids); E=$(wc -l < /tmp/cur.ids)
+comm -12 /tmp/gen.ids /tmp/cur.ids > /tmp/tested.ids      # G ∩ E  = e2e-tested
+comm -23 /tmp/gen.ids /tmp/cur.ids > /tmp/gap.ids         # G \ E  = generated but NOT curated (untested)
+TESTED=$(wc -l < /tmp/tested.ids); GAP=$(wc -l < /tmp/gap.ids)
+EXTRA=$(comm -13 /tmp/gen.ids /tmp/cur.ids | wc -l)       # E \ G  = curated w/o generated twin (hand-written/stale)
+
+# manual-intervention as an example-id SET (not a file count — stay consistent with G/E)
+grep -rl "upjet.upbound.io/manual-intervention" examples examples-generated 2>/dev/null \
+  | xargs grep -h "meta.upbound.io/example-id" 2>/dev/null | sed 's/.*example-id: *//' | sort -u > /tmp/manual.ids
+GAP_MANUAL=$(comm -12 /tmp/gap.ids /tmp/manual.ids | wc -l)     # untested AND manual-intervention (expected)
+GAP_ACTIONABLE=$(comm -23 /tmp/gap.ids /tmp/manual.ids | wc -l) # the REAL coverage debt
+
+echo "generated=$G curated=$E tested(G∩E)=$TESTED gap(G\\E)=$GAP (manual=$GAP_MANUAL actionable=$GAP_ACTIONABLE) extra(E\\G)=$EXTRA"
+echo "raw coverage% = TESTED / G"                          # headline figure (adjust the GAP, not the denominator)
+
+# the actionable untested resources (gap minus expected manual-intervention)
+comm -23 /tmp/gap.ids /tmp/manual.ids
+```
+Notes:
+- `examples-generated/` and `examples/` use **different directory layouts** — that is why you join on
+  `example-id`, never on path or raw file count.
+- If `examples-generated/` is absent, this metric can't be computed — assess `examples/` + uptest
+  wiring qualitatively and say so.
+- Content-diff spot check (sampled id present in both): the curated file should differ from its
+  generated twin. To find a generated twin by id: `grep -rl "example-id: <id>" examples-generated`.
+
+## External-name strategy distribution
+```bash
+grep -hoE 'config\.[A-Za-z]+|IdentifierFromProvider' config/externalname.go | sort | uniq -c | sort -rn | head
+# a very high share of bare IdentifierFromProvider across all resources is a smell (item 3.2)
+```
+
+## Controller / runtime conventions
+```bash
+grep -rl "func SetupGated" internal/controller | head      # SafeStart (7.4)
+grep -rl "func Setup(" internal/controller | head           # base Setup (7.1)
+grep -hE 'EnableBetaManagementPolicies|EnableAlphaExternalSecretStores' internal/features/features.go
+grep -hE 'enable-management-policies|max-reconcile-rate|--poll|--sync' cmd/provider/*/zz_main.go | sort -u | head
+```
+
+## Packaging / capabilities
+```bash
+grep -nE 'SafeStart|provider-family|dependsOn|meta.crossplane.io' package/crossplane.yaml.tmpl
+grep -nE 'SafeStart|provider-family|dependsOn|meta.crossplane.io' package/crossplane.yaml
+ls package/crds | wc -l
+```
+
+## Linting — read the enabled set, not the file size
+```bash
+sed -n '1,80p' .golangci.yml          # inspect the actual enabled linters / version / exclusions
+golangci-lint version 2>/dev/null && golangci-lint run --timeout 5m ./config/... 2>&1 | tail -20   # optional, may be slow
+```
+
+## CI jobs present
+```bash
+ls .github/workflows
+grep -rhoE 'crddiff|schema-version-diff|check-diff|uptest|publish' .github/workflows | sort -u
+grep -E 'crddiff|schema-version-diff|uptest' Makefile
+```
+
+## Breaking-change tooling (optional, needs tools)
+```bash
+make crddiff 2>&1 | tail -20            # only if uptest/crddiff tool installed
+make schema-version-diff 2>&1 | tail -20
+```

--- a/.agent/skills/review-upjet-provider/references/report-template.md
+++ b/.agent/skills/review-upjet-provider/references/report-template.md
@@ -1,0 +1,64 @@
+# Report template
+
+Fill this in. Keep every finding backed by `file:line` or command output. Delete N-A categories'
+detail but keep them in the scorecard marked N/A with the reason.
+
+---
+
+```markdown
+# ⚠️ Experimental - validate all results
+# Upjet Provider Best Practices Review — <provider name>
+
+- **Target:** <repo / path>  ·  **Commit:** <sha>  ·  **Reviewed:** <date>
+- **Measured against:** official Upbound `provider-upjet-{aws,azure,gcp}` conventions (baseline.md)
+
+## Detected profile
+- **Generator:** upjet vN  ·  **Backend:** Plugin-SDK / Plugin-Framework / no-fork
+- **Crossplane model:** v2 (cluster+namespaced) / v1 (single-scope)
+- **Packaging:** family (N service packages) / monolith-only
+- **Build:** crossplane/build submodule / custom
+- *(Tiers below are gated on this profile; items not applicable are marked N/A.)*
+
+## Scorecard
+| # | Category | MUST | SHOULD | NICE | Status |
+|---|----------|------|--------|------|--------|
+| 1 | Repo structure & build | x/x | x/x | x/x | ✅/⚠️/❌/NA |
+| 2 | Code generation | | | | |
+| 3 | External-name & config | | | | |
+| 4 | API types & versioning | | | | |
+| 5 | v2 scope architecture | | | | NA if v1 |
+| 6 | Family & packaging | | | | |
+| 7 | Controller runtime wiring | | | | |
+| 8 | Examples & e2e coverage | | | | |
+| 9 | Testing & linting | | | | |
+| 10 | CI/CD & governance | | | | |
+
+**e2e example coverage:** `<tested>/<generated>` ≈ `<raw pct>%`  ·  untested gap `<G\E>` =
+  `<actionable>` actionable + `<manual>` manual-intervention  ·  curated-only `<E\G>`.
+
+## Overall verdict: **FOLLOWING-BEST-PRACTICES / FOLLOWING-BEST-PRACTICES-WITH-GAPS / NOT-FOLLOWING-BEST-PRACTICES**
+> Gating: any MUST failure → NOT-FOLLOWING-BEST-PRACTICES; only SHOULD/NICE gaps → FOLLOWING-BEST-PRACTICES-WITH-GAPS; clean → FOLLOWING-BEST-PRACTICES.
+One-paragraph rationale.
+
+## Findings
+For each category, list only items that are ❌ / ⚠️ (and noteworthy ✅). Format:
+
+### N. <Category>
+- **[MUST] ❌ <item>** — <what's wrong>. Evidence: `path:line`. Fix: <one line, cite baseline>.
+- **[SHOULD] ⚠️ <item>** — <gap>. Evidence: `path`. Fix: <one line>.
+
+## Top remediation priorities
+1. **(MUST)** …
+2. **(MUST)** …
+3. **(SHOULD)** …
+
+## Untested resources (examples gap)
+<the `G \ E` list, or a count + link if long>
+```
+
+---
+
+**Verdict gating rule (apply mechanically):**
+- ≥1 MUST fail → `NOT-FOLLOWING-BEST-PRACTICES`
+- 0 MUST fail, ≥1 SHOULD/NICE gap → `FOLLOWING-BEST-PRACTICES-WITH-GAPS`
+- all pass / only N-A → `FOLLOWING-BEST-PRACTICES`

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agent/skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# upjet-provider-template — Agent Guide
+
+This is a **Crossplane v2 Upjet provider template**. It wraps any Terraform provider and generates cluster-scoped and namespaced Crossplane managed resources from a declarative config, with no hand-written controllers.
+
+> **Bootstrap**: If you are setting up a new provider from this template, invoke the `bootstrap-upjet-provider` skill before touching any files.
+> **Adding a resource**: Use the `add-upjet-resource` skill.
+
+---
+
+## Architecture
+
+### Dual-scope generation
+
+Every resource is generated **twice** from the same `config/`:
+
+| Scope | Root group | ProviderConfig kind | API version example |
+|---|---|---|---|
+| Cluster | `template.crossplane.io` | `ProviderConfig` | `null.template.crossplane.io/v1alpha1` |
+| Namespaced | `template.m.crossplane.io` | `ClusterProviderConfig` | `null.template.m.crossplane.io/v1alpha1` |
+
+`config/provider.go` calls `GetProvider()` (cluster) and `GetProviderNamespaced()` (namespaced). The generator in `cmd/generator/main.go` runs `pipeline.Run(GetProvider(), GetProviderNamespaced(), rootDir)`.
+
+CRD group formula: `<shortGroup>.<rootGroup>` — e.g. short group `null` + root group `template.crossplane.io` → `null.template.crossplane.io`.
+
+### Codegen pipeline
+
+`make generate` runs these steps in order:
+1. Downloads Terraform ≤1.5 via `build/` submodule tools.
+2. Initialises a minimal `.work/terraform/main.tf.json` and runs `terraform providers schema -json` → **`config/schema.json`** (do not edit).
+3. Clones the TF provider repo (sparse, tag pinned) and scrapes its docs → **`config/provider-metadata.yaml`** (do not edit).
+4. Runs `go generate ./apis/...` which invokes:
+   - `cmd/generator/main.go` → rewrites `apis/cluster/`, `apis/namespaced/`, `internal/controller/cluster/`, `internal/controller/namespaced/`, `examples-generated/`, `config/generated.lst`.
+   - `controller-gen` → `package/crds/`.
+   - `angryjet` → managed-resource methodsets.
+
+---
+
+## Repository structure
+
+```
+config/
+  provider.go               ← resourcePrefix, modulePath, WithRootGroup, group imports  ✏️
+  external_name.go          ← ExternalNameConfigs (also gates generation include list)  ✏️
+  schema.json               ← TF provider schema                                        🚫 generated
+  provider-metadata.yaml    ← scraped TF provider docs                                  🚫 generated
+  generated.lst             ← list of generated resource names                          🚫 generated
+  cluster/<group>/config.go ← per-group AddResourceConfigurator (cluster scope)         ✏️
+  namespaced/<group>/config.go ← same, namespaced scope (must match cluster)            ✏️
+  cluster/provider.go       ← registers group Configure functions (cluster)             ✏️
+  namespaced/provider.go    ← registers group Configure functions (namespaced)          ✏️
+
+apis/
+  cluster/                  ← generated API types (zz_* files)                          🚫 generated
+  namespaced/               ← generated API types (zz_* files)                          🚫 generated
+  generate.go               ← //go:generate directives that drive make generate         ✏️ rarely
+
+internal/
+  clients/                  ← TF setup fn; provider credential extraction               ✏️
+  controller/cluster/       ← generated controllers                                     🚫 generated
+  controller/namespaced/    ← generated controllers                                     🚫 generated
+  features/                 ← feature flags                                             ✏️ rarely
+
+cmd/
+  generator/main.go         ← runs pipeline.Run(GetProvider(), GetProviderNamespaced()) ✏️ rarely
+  provider/main.go          ← provider binary entry point                              ✏️ rarely
+
+package/
+  crossplane.yaml           ← provider name in the OCI package                         ✏️
+  crds/                     ← generated CRD manifests                                  🚫 generated
+
+examples/
+  cluster/<group>/          ← curated E2E examples (cluster scope)                     ✏️
+  namespaced/<group>/       ← curated E2E examples (namespaced scope)                  ✏️
+  cluster/providerconfig/   ← ProviderConfig + Secret template                         ✏️
+  namespaced/providerconfig/← ProviderConfig + ClusterProviderConfig + Secret template ✏️
+  install.yaml              ← provider install manifest                                ✏️
+
+examples-generated/         ← raw generated examples (starting point only)             🚫 generated
+
+cluster/test/setup.sh       ← E2E cluster setup: creates Secret + ProviderConfig       ✏️
+
+Makefile                    ← provider knobs at the top (see below)                    ✏️
+build/                      ← crossplane/build submodule — do not edit                 🚫 submodule
+```
+
+`✏️` = hand-written (safe to edit). `🚫` = generated or submodule (never edit directly).
+
+---
+
+## Makefile knobs
+
+These variables at the top of `Makefile` must be updated when bootstrapping a new provider:
+
+```makefile
+PROJECT_NAME                   # repo name, e.g. provider-upjet-aws
+TERRAFORM_PROVIDER_SOURCE      # TF registry source, e.g. hashicorp/aws
+TERRAFORM_PROVIDER_REPO        # git clone URL for pulling docs
+TERRAFORM_PROVIDER_VERSION     # TF provider version (must be < 1.6 licensed)
+TERRAFORM_PROVIDER_DOWNLOAD_NAME  # binary name on releases.hashicorp.com
+TERRAFORM_NATIVE_PROVIDER_BINARY  # binary filename with version suffix
+TERRAFORM_DOCS_PATH            # relative path to docs dir inside the TF provider repo
+```
+
+`PROJECT_REPO` is derived as `github.com/crossplane/$(PROJECT_NAME)` — update it if the Go module path differs from this pattern.
+
+---
+
+## Key commands
+
+```bash
+# After any fresh clone or worktree — MUST run first
+git submodule update --init --recursive
+
+# Full codegen (schema pull + doc scrape + code generation)
+make generate
+
+# Run only the Go generator (schema + metadata already present)
+go run cmd/generator/main.go "$PWD"
+
+# Verify compilation
+go build ./...
+
+# Run provider out-of-cluster (needs a kubeconfig)
+make run
+
+# E2E test (builds provider, spins up a KinD cluster, runs uptest/chainsaw)
+UPTEST_EXAMPLE_LIST="examples/cluster/<group>/<kind>.yaml" \
+UPTEST_CLOUD_CREDENTIALS="$(cat path/to/creds.json)" \
+UPTEST_DATASOURCE_PATH="path/to/datasource.ini" \
+make e2e
+
+# After any E2E run — ALWAYS clean up in this order
+kubectl delete managed --all --all-namespaces
+kind delete cluster --name local-dev
+```
+
+---
+
+## Config key concepts
+
+### ExternalNameConfigs gates generation
+
+A resource absent from `config/external_name.go` is **never generated**, even if it is in `GroupMap`. Adding a resource here is always step one.
+
+### Group and Kind naming
+
+Upjet derives `shortGroup` and `Kind` from the TF resource name by default (strips the provider prefix, splits on `_`). Override via:
+- `config/groups.go` `GroupMap` — if the provider uses versioned or multi-word group names.
+- `r.ShortGroup` / `r.Kind` inside an `AddResourceConfigurator` call.
+
+### References
+
+Cross-resource references (`r.References["field"] = config.Reference{...}`) go in both `config/cluster/<group>/config.go` AND `config/namespaced/<group>/config.go`. These files must stay in sync.
+
+### Sensitive fields
+
+Any TF attribute marked `Sensitive: true` becomes `<field>SecretRef` in the CRD (references a `v1/Secret`). The plain field name is absent from `forProvider`. Check CRD `keys` when a field seems missing.
+
+---
+
+## E2E setup
+
+`cluster/test/setup.sh` runs during `make e2e`. It:
+1. Creates a `provider-secret` Secret in `crossplane-system` from `$UPTEST_CLOUD_CREDENTIALS`.
+2. Applies a `ProviderConfig` (cluster scope) and a `ProviderConfig` (namespaced scope, in `crossplane-system`).
+
+Update this file to match the new provider's auth structure when bootstrapping.
+
+The `UPTEST_DATASOURCE_PATH` ini file resolves `${data.<key>}` placeholders in example YAML files (e.g. `parentId: ${data.aws_account_id}`).
+
+---
+
+## Crossplane v2 notes
+
+- Both scopes are `SafeStart`-capable (`package/crossplane.yaml`).
+- Cluster-scoped ProviderConfig kind for namespaced resources is **`ClusterProviderConfig`** (not `ProviderConfig`).
+- Managed resources in the namespaced scope reference it with `providerConfigRef.kind: ClusterProviderConfig`.
+- Namespace for namespaced managed resources and Secrets: **`upbound-system`** in examples (or whatever namespace the user creates them in).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
### Description of your changes
Adds following skills:
* review-upjet-provider
* add-upjet-resource

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
`review-upjet-preview` has been tested against few providers (harbor, nebius, non-upjet anthropic)
`add-upjet-resource` has been tested extensively against nebius provider

[contribution process]: https://git.io/fj2m9
